### PR TITLE
fixed vertical mounting issue

### DIFF
--- a/bhy2_defs.h
+++ b/bhy2_defs.h
@@ -717,7 +717,7 @@ enum bhy2_data_inj_mode {
     BHY2_STEP_BY_STEP_INJECTION = 2
 };
 
-#define BHY2_BYTE_TO_NIBBLE(X) (((uint8_t)(X)[0] & 0x0F) | (((uint8_t)(X)[1] << 4) & 0x0F))
+#define BHY2_BYTE_TO_NIBBLE(X) (((uint8_t)(X)[0] & 0x0F) | (((uint8_t)(X)[1] << 4) & 0xF0))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Problem:
The current code zeros rotation matrix entries at indices: 1, 3, 5, and 7
Effect:
Wrong sensor values in some axes remapping scenarios in which non-zero entries exist at those affected indices
How to recreate the problem:
Write [0,-1,0,0,0,-1,1,0,0] as a new rotation matrix and then readback
Recommended Fix:
Instead of low 4-bit, high 4-bit should be preserved in #define BHY2_BYTE_TO_NIBBLE(X)
